### PR TITLE
feat: change default min pool connections

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,7 +5,7 @@ import type {ExLogger, PDOptions} from './types';
 export const defaultKnexOptions: Knex.Config = {
     client: 'pg',
     pool: {
-        min: 2,
+        min: 0,
         max: 10,
         acquireTimeoutMillis: 40000,
         createTimeoutMillis: 50000,


### PR DESCRIPTION
To avoid the problem "Connection terminated unexpectedly" recommended min pool is 0. 

https://github.com/knex/knex/issues/3523
https://knexjs.org/guide/#pool