### PR TITLE
feat!: terminate on signal without exit process

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -19,7 +19,7 @@ export const defaultDispatcherOptions: PDOptions = {
     healthcheckInterval: 5000,
     healthcheckTimeout: 700,
     suppressStatusLogs: false,
-    beforeTerminate: () => Promise.resolve().then(() => process.exit(0)),
+    beforeTerminate: () => Promise.resolve(),
 };
 
 export const defaultExLogger: ExLogger = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -19,7 +19,7 @@ export const defaultDispatcherOptions: PDOptions = {
     healthcheckInterval: 5000,
     healthcheckTimeout: 700,
     suppressStatusLogs: false,
-    beforeTerminate: () => Promise.resolve(),
+    beforeTerminate: () => Promise.resolve().then(() => process.exit(0)),
 };
 
 export const defaultExLogger: ExLogger = {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -75,17 +75,13 @@ export function initDB({
         beforeTerminate()
             .catch(() => {})
             .then(() => db.terminate())
-            .then(() => process.exit(0))
             .catch((error: unknown) => {
                 // eslint-disable-next-line no-console
                 console.error(error);
-                process.exit(-1);
             });
     };
 
     process.on('SIGINT', terminate);
-    process.on('SIGUSR1', terminate);
-    process.on('SIGUSR2', terminate);
 
     const CoreBaseModel = getModel();
     CoreBaseModel.db = db;

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -118,5 +118,5 @@ export function initDB({
         },
     };
     logger.info('Core-db is up and running!');
-    return {db, CoreBaseModel, helpers};
+    return {db, terminate, CoreBaseModel, helpers};
 }


### PR DESCRIPTION
Motivation/Problem:
- on terminate connection OR send signal `SIGUSR1`, `SIGUSR2` process exited
- can't create the signal processing logic in the application

Changes:
- remove terminate connections on `SIGUSR1`, `SIGUSR2`
- remove `process.exit(...)` in terminate connections