### PR TITLE
feat: add cancelOnTimeout and useLimitInFirst params to getModel

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -13,14 +13,15 @@ export interface CoreDBDispatcherOptions {
     beforeTerminate?: () => Promise<void>;
 }
 
+export type GetModelParams = {cancelOnTimeout?: boolean; useLimitInFirst?: boolean};
+
 export interface CoreDBConstructorArgs {
     connectionString: string;
     dispatcherOptions?: CoreDBDispatcherOptions;
     knexOptions?: Knex.Config;
     logger?: ExLogger;
+    modelParams?: GetModelParams;
 }
-
-export type GetModelParams = {cancelOnTimeout?: boolean; useLimitInFirst?: boolean};
 
 export function getModel(params: GetModelParams = {}): typeof BaseModel {
     let _db: PGDispatcher;
@@ -82,6 +83,7 @@ export function initDB({
     dispatcherOptions,
     knexOptions = {},
     logger = defaultExLogger,
+    modelParams,
 }: CoreDBConstructorArgs) {
     if (!connectionString) {
         throw new Error('Empty connection string');
@@ -110,7 +112,7 @@ export function initDB({
 
     process.on('SIGINT', terminate);
 
-    const CoreBaseModel = getModel();
+    const CoreBaseModel = getModel(modelParams);
     CoreBaseModel.db = db;
 
     const helpers = {


### PR DESCRIPTION
Added new params to `getModel`:
- `cancelOnTimeout` – sets default value for `cancel` option in the `timeout` method to `true` – https://knexjs.org/guide/query-builder.html#knex
- `useLimitInFirst` – changes default behavior for the `first()` method, this option will add `LIMIT 1` to the query – https://vincit.github.io/objection.js/api/query-builder/other-methods.html#first