### PR TITLE
feat: add proxy topology mode for SPQR-compatible routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,24 @@ export const {db, CoreBaseModel, helpers} = initDB({
 
 - `connectionString` is a set of [postgres connection strings](https://stackoverflow.com/questions/3582552/postgresql-connection-url) separated by a comma, with at least one host required, for example: `'postgresql://user:password@dbHost1:5432/dbName,postgresql://user:password@dbHost2:5432/dbName'`
 - `logger`: Provide the `info` and `error` callbacks for logging messages
-- `dispatcherOptions`: Settings for the primary/replica balancing (none of the options are required)
+- `dispatcherOptions`: Settings for connection balancing (none of the options are required)
   - `healthcheckInterval`: Health check interval in milliseconds, default value: 5000ms
   - `healthcheckTimeout`: Health check interval in milliseconds, default value: 700ms
-  - `suppressStatusLogs`: Boolean value that disables database health checks (useful for developers)
+  - `suppressStatusLogs`: Boolean value that disables database health-check status logs (useful for developers)
   - `beforeTerminate`: Function called before terminating a connection, must return a Promise
+  - `topologyMode`: Connection topology, either `primary-replica` (the default) or `proxy`
 - `knexOptions`: Non-required additional options that will be passed to Knex before initialization
+
+When all connection strings point to equivalent proxy or router instances, such as SPQR routers, use `proxy` mode. Healthy endpoints are then eligible for both primary and replica queries, and the endpoint with the lowest latest health-check latency is selected:
+
+```typescript
+initDB({
+  connectionString: process.env.POSTGRES_DSN_LIST,
+  dispatcherOptions: {
+    topologyMode: 'proxy',
+  },
+});
+```
 
 Here is the recommended project structure (we only list the directories that have to do with working with the database):
 
@@ -82,7 +94,7 @@ The `initDB` constructor exports three elements: `db`, `CoreBaseModel`, and `hel
 
 ### db
 
-`db`: Instance of the [PGDispatcher](https://github.com/gravity-ui/postgreskit/blob/main/lib/dispatcher.ts) module responsible for primary/replica connection balancing. Under the hood, this module creates N instances of knex (N is the number of hosts passed in `connectionString`). From these instances, it polls the database hosts every `healthcheckInterval` milliseconds, requesting if they are primary hosts or replica hosts (using the `SELECT pg_is_in_recovery()` query).
+`db`: Instance of the [PGDispatcher](https://github.com/gravity-ui/postgreskit/blob/main/lib/dispatcher.ts) module responsible for connection balancing. Under the hood, this module creates N instances of knex (N is the number of hosts passed in `connectionString`). By default, it polls the database hosts every `healthcheckInterval` milliseconds, requesting if they are primary hosts or replica hosts (using the `SELECT pg_is_in_recovery()` query). In `proxy` topology mode, it uses `SELECT 1` instead and routes both `db.primary` and `db.replica` to the fastest healthy endpoint.
 
 Public `db` methods:
 

--- a/jest/unit.config.js
+++ b/jest/unit.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    clearMocks: true,
+    rootDir: '..',
+    testEnvironment: 'node',
+    testMatch: ['<rootDir>/tests/**/*.test.js'],
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,6 +20,7 @@ export const defaultDispatcherOptions: PDOptions = {
     healthcheckTimeout: 700,
     suppressStatusLogs: false,
     beforeTerminate: () => Promise.resolve(),
+    topologyMode: 'primary-replica',
 };
 
 export const defaultExLogger: ExLogger = {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -4,13 +4,16 @@ import {type Constructor, Model} from 'objection';
 
 import {defaultDispatcherOptions, defaultExLogger, defaultKnexOptions} from './constants';
 import {PGDispatcher} from './dispatcher';
-import type {BaseModel, ExLogger} from './types';
+import type {BaseModel, ExLogger, TopologyMode} from './types';
+
+export type {TopologyMode} from './types';
 
 export interface CoreDBDispatcherOptions {
     healthcheckInterval?: number;
     healthcheckTimeout?: number;
     suppressStatusLogs?: boolean;
     beforeTerminate?: () => Promise<void>;
+    topologyMode?: TopologyMode;
 }
 
 export type GetModelParams = {cancelOnTimeout?: boolean; useLimitInFirst?: boolean};

--- a/lib/dispatcher.ts
+++ b/lib/dispatcher.ts
@@ -138,7 +138,7 @@ export class PGDispatcher {
     get primary() {
         this.checkConnectionsAvailability();
 
-        if (this.options.topologyMode === 'proxy') {
+        if (this.isProxyMode) {
             return this.fastestHealthyConnection.knex;
         }
 
@@ -164,7 +164,7 @@ export class PGDispatcher {
     get replica() {
         this.checkConnectionsAvailability();
 
-        if (this.options.topologyMode === 'proxy') {
+        if (this.isProxyMode) {
             return this.fastestHealthyConnection.knex;
         }
 
@@ -221,7 +221,7 @@ export class PGDispatcher {
     }
 
     private async performCheckupQuery(knex: Knex): Promise<PDCheckupResult> {
-        if (this.options.topologyMode === 'proxy') {
+        if (this.isProxyMode) {
             await knex.raw('SELECT 1;').timeout(this.options.healthcheckTimeout);
 
             return {pingOk: true, primary: false};
@@ -290,6 +290,10 @@ export class PGDispatcher {
 
     private get healthyConnections() {
         return this.connections.filter((c) => c.healthy);
+    }
+
+    private get isProxyMode() {
+        return this.options.topologyMode === 'proxy';
     }
 
     private get fastestHealthyConnection() {

--- a/lib/dispatcher.ts
+++ b/lib/dispatcher.ts
@@ -202,9 +202,10 @@ export class PGDispatcher {
                 this.logger.info({
                     message: 'Database current status',
                     data: {
+                        ...(this.isProxyMode ? {topologyMode: this.options.topologyMode} : {}),
                         connections: this.connections.map((c) => ({
                             host: c.host,
-                            primary: c.primary,
+                            ...(this.isProxyMode ? {} : {primary: c.primary}),
                             healthy: c.healthy,
                             latency: c.latency,
                         })),

--- a/lib/dispatcher.ts
+++ b/lib/dispatcher.ts
@@ -138,6 +138,10 @@ export class PGDispatcher {
     get primary() {
         this.checkConnectionsAvailability();
 
+        if (this.options.topologyMode === 'proxy') {
+            return this.fastestHealthyConnection.knex;
+        }
+
         const primaryConnections = this.connections.filter((c) => c.primary);
         if (primaryConnections.length > 1) {
             this.logger.error({
@@ -159,6 +163,10 @@ export class PGDispatcher {
 
     get replica() {
         this.checkConnectionsAvailability();
+
+        if (this.options.topologyMode === 'proxy') {
+            return this.fastestHealthyConnection.knex;
+        }
 
         const replicaConnections = this.healthyConnections.filter((c) => !c.primary);
 
@@ -213,6 +221,12 @@ export class PGDispatcher {
     }
 
     private async performCheckupQuery(knex: Knex): Promise<PDCheckupResult> {
+        if (this.options.topologyMode === 'proxy') {
+            await knex.raw('SELECT 1;').timeout(this.options.healthcheckTimeout);
+
+            return {pingOk: true, primary: false};
+        }
+
         const result = await knex
             .raw('SELECT pg_is_in_recovery();')
             .timeout(this.options.healthcheckTimeout);
@@ -276,6 +290,10 @@ export class PGDispatcher {
 
     private get healthyConnections() {
         return this.connections.filter((c) => c.healthy);
+    }
+
+    private get fastestHealthyConnection() {
+        return this.healthyConnections.sort((a, b) => a.latency - b.latency)[0];
     }
 
     private checkConnectionsAvailability() {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,11 +1,14 @@
 import type {Model} from 'objection';
 import type {PGDispatcher} from './dispatcher';
 
+export type TopologyMode = 'primary-replica' | 'proxy';
+
 export interface PDOptions {
     healthcheckInterval: number;
     healthcheckTimeout: number;
     suppressStatusLogs: boolean;
     beforeTerminate: () => Promise<void>;
+    topologyMode: TopologyMode;
 }
 
 export type Dict = {[key: string]: unknown};

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "prepublishOnly": "npm run build",
     "prepare": "husky install",
     "test:prepare": "npm run build && cd ./examples/demo && npm run build && cd ../../",
+    "test:unit": "jest -c ./jest/unit.config.js",
     "test:run": "JEST_TESTCONTAINERS_CONFIG_PATH='./jest/testcontainers-config.js' NODE_TLS_REJECT_UNAUTHORIZED=0 APP_LOGGING_LEVEL='silent' APP_ENV='test' jest -c './jest/jest.config.js' --detectOpenHandles",
-    "test": "npm run test:prepare && npm run test:run"
+    "test": "npm run test:prepare && npm run test:unit && npm run test:run"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -94,6 +94,15 @@ describe('PGDispatcher topology modes', () => {
         }
         expect(dispatcher.primary).toBe(fasterProxy);
         expect(dispatcher.replica).toBe(fasterProxy);
+
+        const statusLog = logger.info.mock.calls.find(
+            ([message]) => message === 'Database current status',
+        );
+        expect(statusLog[1].topologyMode).toBe('proxy');
+        for (const connection of statusLog[1].connections) {
+            expect(connection).not.toHaveProperty('primary');
+        }
+
         expect(loggedErrorMessages(logger)).not.toEqual(
             expect.arrayContaining([
                 'Multiple primary connections detected, something is wrong',

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -103,12 +103,11 @@ describe('PGDispatcher topology modes', () => {
             expect(connection).not.toHaveProperty('primary');
         }
 
-        expect(loggedErrorMessages(logger)).not.toEqual(
-            expect.arrayContaining([
-                'Multiple primary connections detected, something is wrong',
-                'No alive replica available, using master for read',
-            ]),
+        const errorMessages = loggedErrorMessages(logger);
+        expect(errorMessages).not.toContain(
+            'Multiple primary connections detected, something is wrong',
         );
+        expect(errorMessages).not.toContain('No alive replica available, using master for read');
     });
 
     test('the existing unavailable-database error is preserved when all proxies are unhealthy', async () => {

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -78,6 +78,23 @@ describe('PGDispatcher topology modes', () => {
         expect(dispatcher.replica).toBe(replica);
     });
 
+    test('the default mode emits primary/replica topology warnings', async () => {
+        const firstPrimary = createKnex(successfulCheckup({pg_is_in_recovery: false}));
+        const secondPrimary = createKnex(successfulCheckup({pg_is_in_recovery: false}));
+        const {dispatcher, logger} = createDispatcher([firstPrimary, secondPrimary]);
+
+        await dispatcher.ready();
+
+        expect(dispatcher.primary).toBe(firstPrimary);
+        expect(dispatcher.replica).toBe(firstPrimary);
+
+        const errorMessages = loggedErrorMessages(logger);
+        expect(errorMessages).toContain(
+            'Multiple primary connections detected, something is wrong',
+        );
+        expect(errorMessages).toContain('No alive replica available, using master for read');
+    });
+
     test('proxy mode routes both roles to the fastest healthy endpoint without topology warnings', async () => {
         const slowerProxy = createKnex(successfulCheckup({value: 1}, 30));
         const fasterProxy = createKnex(successfulCheckup({value: 1}, 5));

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -1,0 +1,122 @@
+/* eslint-env jest */
+
+jest.mock('knex', () => jest.fn());
+
+const knexBuilder = require('knex');
+
+const {defaultDispatcherOptions} = require('../build/constants');
+const {PGDispatcher} = require('../build/dispatcher');
+
+const activeDispatchers = [];
+
+function createKnex(checkup) {
+    const timeout = jest.fn(() => checkup());
+
+    return {
+        destroy: jest.fn(() => Promise.resolve()),
+        raw: jest.fn(() => ({timeout})),
+        timeout,
+    };
+}
+
+function successfulCheckup(row, latency = 0) {
+    return () =>
+        new Promise((resolve) => {
+            setTimeout(() => resolve({rows: [row]}), latency);
+        });
+}
+
+function failedCheckup() {
+    return Promise.reject(new Error('Proxy unavailable'));
+}
+
+function createDispatcher(clients, options = {}) {
+    clients.forEach((client) => knexBuilder.mockImplementationOnce(() => client));
+
+    const logger = {
+        error: jest.fn(),
+        info: jest.fn(),
+    };
+    const dispatcher = new PGDispatcher({
+        connections: clients.map(
+            (_, index) => `postgresql://user:password@database-${index}.example/db`,
+        ),
+        logger,
+        options: {
+            ...defaultDispatcherOptions,
+            healthcheckInterval: 60_000,
+            healthcheckTimeout: 100,
+            ...options,
+        },
+    });
+
+    activeDispatchers.push(dispatcher);
+
+    return {dispatcher, logger};
+}
+
+function loggedErrorMessages(logger) {
+    return logger.error.mock.calls.map(([, error]) => error.message);
+}
+
+afterEach(async () => {
+    await Promise.all(activeDispatchers.splice(0).map((dispatcher) => dispatcher.terminate()));
+});
+
+describe('PGDispatcher topology modes', () => {
+    test('the default mode keeps the primary/replica health check and routing behavior', async () => {
+        const primary = createKnex(successfulCheckup({pg_is_in_recovery: false}));
+        const replica = createKnex(successfulCheckup({pg_is_in_recovery: true}));
+        const {dispatcher} = createDispatcher([primary, replica]);
+
+        await dispatcher.ready();
+
+        expect(defaultDispatcherOptions.topologyMode).toBe('primary-replica');
+        expect(primary.raw).toHaveBeenCalledWith('SELECT pg_is_in_recovery();');
+        expect(replica.raw).toHaveBeenCalledWith('SELECT pg_is_in_recovery();');
+        expect(dispatcher.primary).toBe(primary);
+        expect(dispatcher.replica).toBe(replica);
+    });
+
+    test('proxy mode routes both roles to the fastest healthy endpoint without topology warnings', async () => {
+        const slowerProxy = createKnex(successfulCheckup({value: 1}, 30));
+        const fasterProxy = createKnex(successfulCheckup({value: 1}, 5));
+        const unhealthyProxy = createKnex(failedCheckup);
+        const {dispatcher, logger} = createDispatcher([slowerProxy, fasterProxy, unhealthyProxy], {
+            topologyMode: 'proxy',
+        });
+
+        await dispatcher.ready();
+
+        for (const proxy of [slowerProxy, fasterProxy, unhealthyProxy]) {
+            expect(proxy.raw).toHaveBeenCalledWith('SELECT 1;');
+            expect(proxy.raw).not.toHaveBeenCalledWith('SELECT pg_is_in_recovery();');
+        }
+        expect(dispatcher.primary).toBe(fasterProxy);
+        expect(dispatcher.replica).toBe(fasterProxy);
+        expect(loggedErrorMessages(logger)).not.toEqual(
+            expect.arrayContaining([
+                'Multiple primary connections detected, something is wrong',
+                'No alive replica available, using master for read',
+            ]),
+        );
+    });
+
+    test('the existing unavailable-database error is preserved when all proxies are unhealthy', async () => {
+        const {dispatcher} = createDispatcher(
+            [createKnex(failedCheckup), createKnex(failedCheckup)],
+            {topologyMode: 'proxy'},
+        );
+
+        await dispatcher.ready();
+
+        for (const connection of ['primary', 'replica']) {
+            expect(() => dispatcher[connection]).toThrow(
+                expect.objectContaining({
+                    code: 'ERR_DB_NOT_AVAILABLE',
+                    message: 'No connections available',
+                }),
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Problem

PostgresKit currently assumes that every connection string represents an individual node in a PostgreSQL primary/replica cluster.

To determine each node's role, it periodically executes:

```sql
SELECT pg_is_in_recovery();
```

A `false` result identifies a primary, while `true` identifies a replica.

This assumption does not work for [SPQR](https://github.com/pg-sharding/spqr). The supplied endpoints represent equivalent SPQR router instances rather than individual PostgreSQL nodes. A router can accept both read and write queries and forward them to the appropriate backend.

SPQR routers report themselves as primary for `pg_is_in_recovery()`. Therefore, when several router endpoints are configured, PostgresKit classifies all of them as primaries and may report:

> Multiple primary connections detected, something is wrong

or:

> No alive replica available, using master for read

Having multiple endpoints classified as “masters” is normal for an SPQR deployment: these are equivalent router instances, not multiple writable PostgreSQL primary nodes. The warnings are produced by PostgresKit because its primary/replica topology model does not match the actual SPQR topology.

Suppressing status logs does not solve the problem because it only hides the warnings while leaving the incorrect routing model in place.

## Solution

This PR adds an optional dispatcher topology mode:

```typescript
initDB({
  connectionString: process.env.POSTGRES_DSN_LIST,
  dispatcherOptions: {
    topologyMode: 'proxy',
  },
});
```

In `proxy` mode, PostgresKit:

- uses `SELECT 1` instead of `pg_is_in_recovery()` for health checks;
- treats every healthy endpoint as eligible for both `db.primary` and `db.replica`;
- selects the healthy endpoint with the lowest latest health-check latency;
- excludes unhealthy endpoints;
- does not produce primary/replica topology warnings;
- preserves the existing unavailable-database error when no healthy endpoints remain.

## Backward compatibility

`primary-replica` remains the default topology mode. When `topologyMode` is omitted, the existing health checks, routing behavior, warnings, and errors remain unchanged.

## Testing

Added tests covering:

- existing primary/replica behavior in the default mode;
- role-agnostic proxy health checks;
- fastest healthy proxy selection for both `db.primary` and `db.replica`;
- unhealthy endpoint exclusion;
- behavior when all proxy endpoints are unavailable;
- absence of primary/replica topology warnings in proxy mode.
